### PR TITLE
FIX: Test for CSIP86

### DIFF
--- a/ip_validation/infopacks/resources/schematron/mets_structmap_rules.xml
+++ b/ip_validation/infopacks/resources/schematron/mets_structmap_rules.xml
@@ -11,9 +11,9 @@
     <rule context="/mets:mets/mets:structMap[@LABEL = 'CSIP']">
       <assert id="CSIP83" role="ERROR" test="@ID">An xml:id identifier for the structural description (structMap) used for internal package references. It must be unique within the package.</assert>
       <assert id="CSIP84" role="ERROR" test="mets:div">The structural map MUST comprises a single division.</assert>
-      <assert id="CSIP86" role="ERROR" test="mets:div[@LABEL = /mets:mets/@OBJID]">The package’s top-level structural division div element’s @LABEL attribute value must be identical to the package identifier, i.e. the same value as the mets/@OBJID attribute.</assert>
     </rule>
     <rule context="/mets:mets/mets:structMap[@LABEL = 'CSIP']/mets:div">
+      <assert id="CSIP86" role="ERROR" test="@LABEL = /mets:mets/@OBJID">The package’s top-level structural division div element’s @LABEL attribute value must be identical to the package identifier, i.e. the same value as the mets/@OBJID attribute.</assert>
       <assert id="CSIP85" role="ERROR" test="@ID">An xml:id identifier must be unique within the package.</assert>
       <assert id="CSIP88" role="ERROR" test="mets:div[@LABEL = 'Metadata']">The package’s top-level structural division div element’s @LABEL attribute value must be identical to the package identifier, i.e. the same value as the mets/@OBJID attribute.</assert>
       <assert id="CSIP93" role="WARN" test="mets:div[@LABEL = 'Documentation']">The documentation referenced in the file section file groups is described in the structural map with one sub division.</assert>

--- a/tests/resources/xml/METS-valid.xml
+++ b/tests/resources/xml/METS-valid.xml
@@ -102,7 +102,7 @@
     <!-- CSIP81 mets/structMap/@TYPE The type attribute of the structural map (structMap) is set to value “PHYSICAL” from the vocabualry -->
     <!-- CSIP82 mets/structMap/@LABEL The value must be “CSIP StructMap” -->
     <!-- CSIP83 mets/structMap/@ID -->
-    <div ID="ID-Structmap_Div_ID" LABEL="ID-Minimal_IP_with_schemas">
+    <div ID="ID-Structmap_Div_ID" LABEL="minimal_IP_with_schemas">
       <!-- CSIP84 mets/structMap/div -->
       <!-- CSIP85 mets/structMap/div/@ID -->
       <!-- CSIP86 mets/structMap/div/@LABEL -->


### PR DESCRIPTION
- moved and tweaked Schematron rule for `CSIP86`; and
- fixed the `METS-valid.xml` file that in fact broke `CSIP86`.