### PR TITLE
FIX: Empty METS file handling

### DIFF
--- a/ip_validation/controller.py
+++ b/ip_validation/controller.py
@@ -86,9 +86,9 @@ def validate(digest):
         schema_result = validator.validate_mets(mets_path)
         # Now grab any errors
         schema_errors = validator.validation_errors
-
-        profile.validate(mets_path)
-        prof_results = profile.get_results()
+        if schema_result is True:
+            profile.validate(mets_path)
+            prof_results = profile.get_results()
 
     return render_template('validate.html', details=struct_details, schema_result=schema_result,
                            schema_errors=schema_errors, prof_names=ValidationProfile.NAMES,

--- a/ip_validation/infopacks/rules.py
+++ b/ip_validation/infopacks/rules.py
@@ -91,16 +91,27 @@ class ValidationProfile():
 
     def __init__(self):
         self.rulesets = {}
-        self.results = {}
         self.is_valid = False
+        self.is_wellformed = True
+        self.results = {}
+        self.messages = []
         for section in self.SECTIONS:
             self.rulesets[section] = ValidationRules(section)
 
     def validate(self, to_validate):
         """Validates a file against each loaded ruleset."""
         is_valid = True
+        self.is_wellformed = True
+        self.results = {}
+        self.messages = []
         for section in self.SECTIONS:
-            self.rulesets[section].validate(to_validate)
+            try:
+                self.rulesets[section].validate(to_validate)
+            except lxml.etree.XMLSyntaxError as parse_err:
+                self.is_wellformed = False
+                self.is_valid = False
+                self.messages.append(parse_err.msg)
+                return
             self.results[section] = self.rulesets[section].get_report()
             if not self.results[section].is_valid:
                 is_valid = False

--- a/ip_validation/infopacks/rules.py
+++ b/ip_validation/infopacks/rules.py
@@ -92,7 +92,7 @@ class ValidationProfile():
     def __init__(self):
         self.rulesets = {}
         self.is_valid = False
-        self.is_wellformed = True
+        self.is_wellformed = False
         self.results = {}
         self.messages = []
         for section in self.SECTIONS:


### PR DESCRIPTION
- made Schematron validation dependant on successful Schema validation;
- added capacity for a `ValidationProfile` to record parsing issues; and
- added test for `lxml.etree.XMLSyntaxError` to `ValidationProfile`.

This came up when testing for #14 but isn't the cause of the issue.